### PR TITLE
Recover on invalid username

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/aiooncue/__init__.py
+++ b/aiooncue/__init__.py
@@ -88,7 +88,7 @@ LOGIN_FAILED_CODES = {
     LOGIN_INVALID_USERNAME: "Invalid username",
     LOGIN_INVALID_PASSWORD: "Invalid Password",
 }
-INCORRECT_CREDENTIALS_CODES = { LOGIN_INVALID_PASSWORD }
+INCORRECT_CREDENTIALS_CODES = {LOGIN_INVALID_PASSWORD}
 
 LOGIN_ENDPOINT = "/users/connect"
 
@@ -154,9 +154,9 @@ class Oncue:
 
     async def _get_authenticated(self, endpoint: str, params=None) -> dict:
         if self._auth_invalid:
-            raise LoginFailedException("Authorization invalid will not retry - " +
-                                       self._auth_invalid)
-
+            raise LoginFailedException(
+                f"Authorization invalid will not retry - {self._auth_invalid}"
+            )
         for _ in range(2):
             data = await self._get(endpoint, {"sessionkey": self._sessionkey, **params})
             if "code" not in data or data["code"] not in LOGIN_FAILED_CODES:

--- a/aiooncue/__init__.py
+++ b/aiooncue/__init__.py
@@ -140,7 +140,6 @@ class Oncue:
         self._username = username
         self._password = password
         self._auth_invalid = 0
-        self._sessionkey = None
 
     async def _get(self, endpoint: str, params=None) -> dict:
         """Make a get request."""
@@ -167,7 +166,6 @@ class Oncue:
 
     async def async_login(self) -> None:
         """Call api to login"""
-        self._sessionkey = None
         login_data = await self._get(
             LOGIN_ENDPOINT, {"username": self._username, "password": self._password}
         )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,6 @@ coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
 
-pytest==4.6.5
-pytest-runner==5.1
+pytest==7.4.4
+pytest-runner==6.0.1
 pytest-asyncio==0.23.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ twine==1.14.0
 
 pytest==4.6.5
 pytest-runner==5.1
+pytest-asyncio==0.23.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,4 +10,4 @@ twine==1.14.0
 
 pytest==7.4.4
 pytest-runner==6.0.1
-pytest-asyncio==0.23.4
+pytest-asyncio==0.21.0

--- a/tests/test_aiooncue.py
+++ b/tests/test_aiooncue.py
@@ -3,7 +3,7 @@
 
 """Tests for `aiooncue` package."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 import pytest
 
 import aiohttp
@@ -21,11 +21,8 @@ from aiooncue import (
 async def test_login():
     """Tests login"""
 
-    # The code under test shouldn't access the client session
-    session: aiohttp.ClientSession = None
-
     # Successful Login
-    api = Oncue("username", "password", session)
+    api = Oncue("username", "password", Mock())
     with patch.object(api, "_get") as mock_get:
         mock_get.return_value = {"sessionkey": "123"}
         await api.async_login()

--- a/tests/test_aiooncue.py
+++ b/tests/test_aiooncue.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
+# pylint: disable=protected-access
 
 """Tests for `aiooncue` package."""
 
+from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
+import aiohttp
 
-from aiooncue import Oncue
+
+from aiooncue import LOGIN_INVALID_PASSWORD, LOGIN_INVALID_USERNAME, LoginFailedException, Oncue
 
 
 @pytest.fixture
@@ -22,3 +26,48 @@ def test_content(response):
     """Sample pytest test function with the pytest fixture as an argument."""
     # from bs4 import BeautifulSoup
     # assert 'GitHub' in BeautifulSoup(response.content).title.string
+
+@pytest.mark.asyncio
+async def test_login():
+    """Tests login"""
+
+    # Successful Login
+    session = aiohttp.ClientSession()
+    api = Oncue("username", "password", session)
+    with patch.object(api, "_get") as mock_get:
+        mock_get.return_value = { "sessionkey" : "123" }
+        await api.async_login()
+    assert api._sessionkey == "123"
+    assert api._login_success is True
+    assert api._auth_invalid == 0
+
+    # Relogin and return an invalid username, this should not make the auth_invalid
+    with patch.object(api, "_get") as mock_get:
+        mock_get.return_value = { "code" : LOGIN_INVALID_USERNAME, "sessionkey" : "321" }
+        with pytest.raises(LoginFailedException):
+            await api.async_login()
+    assert api._sessionkey is None
+    assert api._login_success is True
+    assert api._auth_invalid == 0
+
+    # Relogin and return an invalid password, this should make the auth_invalid
+    with patch.object(api, "_get") as mock_get:
+        mock_get.return_value = { "code" : LOGIN_INVALID_PASSWORD, "sessionkey" : "321", "message" : "bad username" }
+        with pytest.raises(LoginFailedException):
+            await api.async_login()
+    assert api._sessionkey is None
+    assert api._login_success is True
+    assert api._auth_invalid == "bad username (1207)"
+
+    # New API object
+    api = Oncue("username", "password", session)
+    # First login and return an invalid username, this should make the auth_invalid
+    with patch.object(api, "_get") as mock_get:
+        mock_get.return_value = { "code" : LOGIN_INVALID_USERNAME, "sessionkey" : "321" }
+        with pytest.raises(LoginFailedException):
+            await api.async_login()
+    assert api._sessionkey is None
+    assert api._login_success is False
+    assert api._auth_invalid != 0
+
+

--- a/tests/test_aiooncue.py
+++ b/tests/test_aiooncue.py
@@ -3,7 +3,7 @@
 
 """Tests for `aiooncue` package."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
 import pytest
 
 import aiohttp

--- a/tests/test_aiooncue.py
+++ b/tests/test_aiooncue.py
@@ -17,23 +17,6 @@ from aiooncue import (
     ServiceFailedException,
 )
 
-
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
-
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
-
-
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument."""
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string
-
-
 @pytest.mark.asyncio
 async def test_login():
     """Tests login"""
@@ -52,7 +35,6 @@ async def test_login():
         mock_get.return_value = {"code": LOGIN_INVALID_USERNAME, "sessionkey": "321"}
         with pytest.raises(ServiceFailedException):
             await api.async_login()
-    assert api._sessionkey is None
     assert api._auth_invalid == 0
 
     # Relogin and return an invalid password, this should make the auth_invalid
@@ -64,5 +46,4 @@ async def test_login():
         }
         with pytest.raises(LoginFailedException):
             await api.async_login()
-    assert api._sessionkey is None
     assert api._auth_invalid == f"bad username ({LOGIN_INVALID_PASSWORD})"

--- a/tests/test_aiooncue.py
+++ b/tests/test_aiooncue.py
@@ -21,8 +21,10 @@ from aiooncue import (
 async def test_login():
     """Tests login"""
 
+    # The code under test shouldn't access the client session
+    session: aiohttp.ClientSession = None
+
     # Successful Login
-    session = aiohttp.ClientSession()
     api = Oncue("username", "password", session)
     with patch.object(api, "_get") as mock_get:
         mock_get.return_value = {"sessionkey": "123"}

--- a/tests/test_aiooncue.py
+++ b/tests/test_aiooncue.py
@@ -65,4 +65,4 @@ async def test_login():
         with pytest.raises(LoginFailedException):
             await api.async_login()
     assert api._sessionkey is None
-    assert api._auth_invalid == "bad username (1207)"
+    assert api._auth_invalid == f"bad username ({LOGIN_INVALID_PASSWORD})"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py37, py38, py39, flake8
+envlist = py311, py312, flake8
 
 [travis]
 python =
-    3.9: py39
-    3.8: py38
-    3.7: py37
+    3.11: py311
+    3.12: py312
 
 [testenv:flake8]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py311, py312, flake8
+envlist = py37, py38, py39, flake8
 
 [travis]
 python =
-    3.11: py311
-    3.12: py312
+    3.9: py39
+    3.8: py38
+    3.7: py37
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
When the Kohler cloud has problems it will sometimes return an Invalid user name error; this causes the API to go into a state where it will never reconnect.

https://github.com/home-assistant/core/issues/111953